### PR TITLE
fix(#27): object (array) destructuring in variable declaration improvements

### DIFF
--- a/src/transformers/Transpiler.ts
+++ b/src/transformers/Transpiler.ts
@@ -11,6 +11,11 @@ type TransformerUtils = {
 export interface VisitNodeContext {
   enforceParameterType?: boolean;
   skipParameterInitializer?: boolean;
+  variableDeclaration?: {
+    variableDeclarationIndent?: string;
+    variableDeclarationKeyword?: string;
+    variableDeclarationInitializer?: string;
+  };
 }
 
 export type TransformerFn = (

--- a/src/transformers/index.ts
+++ b/src/transformers/index.ts
@@ -15,6 +15,8 @@ export const TRANSFORMERS: TransformerFn[] = [
   lang.transformVariableStatement,
   lang.transformVariableDeclarationList,
   lang.transformVariableDeclaration,
+  lang.transformObjectBindingPattern,
+  lang.transformArrayBindingPattern,
   lang.transformBooleanOperatorInVariableDeclaration,
   lang.transformClassDeclaration,
   lang.transformEnumDeclaration,

--- a/src/transformers/lang/variables.ts
+++ b/src/transformers/lang/variables.ts
@@ -23,96 +23,19 @@ export const transformVariableDeclarationList: TransformerFn = function (
   // let foo: string, bar = 4
   if (!ts.isVariableDeclarationList(node)) return;
   const keyword = node.flags & ts.NodeFlags.Const ? 'final' : 'var';
+  const indent = this.utils.getIndent(node);
   return node.declarations
-    .map((dec, declarationIndex) => {
-      // { foo: bar = "wow" } = obj
-      if (ts.isObjectBindingPattern(dec.name)) {
-        const transformBinding = (
-          binding: ts.ObjectBindingPattern,
-          parentPath: string,
-          bindingIndex = 0,
-        ): string => {
-          return binding.elements
-            .map((el, elIndex) => {
-              const start = `${
-                declarationIndex + bindingIndex + elIndex > 0
-                  ? this.utils.getIndent(dec)
-                  : ''
-              }${keyword} `;
-
-              // { foo: { bar: "baz" } } = obj
-              if (ts.isObjectBindingPattern(el.name)) {
-                return transformBinding(
-                  el.name,
-                  `${parentPath}.${this.utils
-                    .visitParenthesized(el.propertyName!, context)
-                    .trimStart()}`,
-                  bindingIndex + 1,
-                );
-              }
-
-              // { ...rest } = obj
-              if (el.dotDotDotToken) {
-                const keysToOmit = binding.elements
-                  .filter((e) => e !== el)
-                  .map(
-                    (e) => `'${e.propertyName?.getText() ?? e.name.getText()}'`,
-                  )
-                  .join(', ');
-                return `${start}${el.name.getText()} = Ts2hx.rest(${parentPath}, [${keysToOmit}])`;
-              }
-
-              // { foo: renamed } = bar
-              let init = `${parentPath}.${this.utils
-                .visitParenthesized(el.propertyName ?? el.name, context)
-                .trimStart()}`;
-              if (el.initializer) {
-                init = `${init} ?? ${this.visitNode(el.initializer, context)}`;
-              }
-              return `${start}${el.name.getText()} = ${init}`;
-            })
-            .join(';\n');
-        };
-
-        return transformBinding(
-          dec.name,
-          this.utils.visitParenthesized(dec.initializer!, context),
-        );
-      }
-
-      // [first, , third, ...rest] = arr
-      if (ts.isArrayBindingPattern(dec.name)) {
-        return dec.name.elements
-          .map((el, elIndex) => {
-            const start = `${
-              declarationIndex + elIndex > 0 ? this.utils.getIndent(dec) : ''
-            }${keyword} `;
-            if (ts.isOmittedExpression(el)) return;
-
-            const name = el.name.getText();
-            const init = this.utils.visitParenthesized(
-              dec.initializer!,
-              context,
-            );
-
-            // [...rest] = arr
-            if (el.dotDotDotToken) {
-              return `${start}${name} = ${init}.slice(${elIndex})`;
-            }
-
-            // [first, second] = arr
-            return `${start}${name} = ${init}[${elIndex}]`;
-          })
-          .filter(Boolean)
-          .join(';\n');
-      }
-
-      const start = `${
-        declarationIndex > 0 ? this.utils.getIndent(dec) : ''
-      }${keyword} `;
-      return `${start} ${this.visitNode(dec, context).trimStart()}`;
-    })
-    .join(';\n');
+    .map((declaration) =>
+      this.visitNode(declaration, {
+        ...context,
+        variableDeclaration: {
+          variableDeclarationIndent: indent,
+          variableDeclarationKeyword: keyword,
+        },
+      }),
+    )
+    .join('')
+    .trimStart();
 };
 
 export const transformVariableDeclaration: TransformerFn = function (
@@ -122,9 +45,182 @@ export const transformVariableDeclaration: TransformerFn = function (
 ) {
   // foo: number = 5
   if (!ts.isVariableDeclaration(node)) return;
-  return `${node.name.getText()}${
-    node.type ? `: ${this.visitNode(node.type, context)}` : ''
-  }${
-    node.initializer ? ` = ${this.visitNode(node.initializer, context)}` : ''
-  }`;
+
+  const { variableDeclarationKeyword: keyword } =
+    context.variableDeclaration ?? {};
+
+  if (ts.isIdentifier(node.name)) {
+    return `${keyword ? `${keyword} ` : ''}${node.name.getText()}${
+      node.type ? `: ${this.visitNode(node.type, context).trimStart()}` : ''
+    }${
+      node.initializer
+        ? ` = ${this.visitNode(node.initializer, context).trimStart()}`
+        : ''
+    }`;
+  }
+
+  // avoid destructuring of parameter in catch clause
+  if (!keyword) return;
+
+  return this.visitNode(node.name, {
+    ...context,
+    variableDeclaration: {
+      ...context.variableDeclaration,
+      variableDeclarationInitializer:
+        node.initializer &&
+        this.utils.visitParenthesized(node.initializer, context),
+    },
+  }).trimStart();
+};
+
+// { foo: bar = 'baz', [bar]: baz, ...rest } = obj
+export const transformObjectBindingPattern: TransformerFn = function (
+  this: Transpiler,
+  node,
+  context,
+) {
+  if (!ts.isObjectBindingPattern(node) || !context.variableDeclaration) {
+    return;
+  }
+
+  const {
+    variableDeclarationIndent = '',
+    variableDeclarationKeyword = '',
+    variableDeclarationInitializer: parentInitializer = '',
+  } = context.variableDeclaration;
+
+  return node.elements
+    .map((element) => {
+      const propertyName = element.propertyName ?? element.name;
+      let initializer = '';
+
+      // { ...rest }
+      if (element.dotDotDotToken) {
+        const keysToOmit = node.elements
+          .filter((e) => e !== element)
+          .map((e) => {
+            const propName = e.propertyName ?? e.name;
+
+            if (ts.isComputedPropertyName(propName)) {
+              return this.visitNode(propName.expression, context).trimStart();
+            } else if (
+              ts.isIdentifier(propName) ||
+              ts.isNumericLiteral(propName)
+            ) {
+              return `'${propName.getText()}'`;
+            }
+
+            return propName.getText();
+          })
+          .join(', ');
+        return (
+          `${variableDeclarationKeyword} ${element.name.getText()}` +
+          ` = Ts2hx.rest(${parentInitializer}, [${keysToOmit}])`
+        );
+      }
+
+      if (ts.isIdentifier(propertyName)) {
+        // { foo: bar } = obj -> obj.foo
+        initializer = `${parentInitializer}.${propertyName.getText()}`;
+      } else {
+        let propertyNameText = '';
+
+        if (ts.isNumericLiteral(propertyName)) {
+          // { 0: bar } = obj -> Reflect.field(obj, '0')
+          propertyNameText = `'${propertyName.getText()}'`;
+        } else if (ts.isComputedPropertyName(propertyName)) {
+          // { [expression]: bar } = obj -> Reflect.field(obj, expression)
+          propertyNameText = this.visitNode(
+            propertyName.expression,
+            context,
+          ).trimStart();
+        } else {
+          // { 'foo': bar } = obj -> Reflect.field(obj, 'foo')
+          propertyNameText = propertyName.getText();
+        }
+
+        initializer = `Reflect.field(${parentInitializer}, ${propertyNameText})`;
+      }
+
+      if (element.initializer) {
+        initializer = `${initializer} ?? ${this.visitNode(
+          element.initializer,
+          context,
+        ).trimStart()}`;
+      }
+
+      // { foo } | { foo: bar } | { [foo]: bar } | { 'foo': bar } | { 0: bar }
+      if (ts.isIdentifier(element.name)) {
+        return `${variableDeclarationKeyword} ${element.name.getText()} = ${initializer}`;
+      }
+
+      // { foo: { bar } } | { foo: [bar] }
+      return this.visitNode(element.name, {
+        ...context,
+        variableDeclaration: {
+          ...context.variableDeclaration,
+          variableDeclarationInitializer: element.initializer
+            ? `(${initializer})`
+            : initializer,
+        },
+      }).trimStart();
+    })
+    .join(`;\n${variableDeclarationIndent}`);
+};
+
+// [first, , third, ...rest] = arr
+export const transformArrayBindingPattern: TransformerFn = function (
+  this: Transpiler,
+  node,
+  context,
+) {
+  if (!ts.isArrayBindingPattern(node) || !context.variableDeclaration) {
+    return;
+  }
+
+  const {
+    variableDeclarationIndent = '',
+    variableDeclarationKeyword = '',
+    variableDeclarationInitializer: parentInitializer = '',
+  } = context.variableDeclaration;
+
+  return node.elements
+    .map((element, index) => {
+      if (ts.isOmittedExpression(element)) return;
+
+      // [...rest] = arr
+      if (element.dotDotDotToken) {
+        return (
+          `${variableDeclarationKeyword} ${element.name.getText()}` +
+          ` = ${parentInitializer}.slice(${index})`
+        );
+      }
+
+      let initializer = `${parentInitializer}[${index}]`;
+
+      if (element.initializer) {
+        initializer = `${initializer} ?? ${this.visitNode(
+          element.initializer,
+          context,
+        ).trimStart()}`;
+      }
+
+      // [first, second] = arr
+      if (ts.isIdentifier(element.name)) {
+        return `${variableDeclarationKeyword} ${element.name.getText()} = ${initializer}`;
+      }
+
+      // [[first, second], { foo }] = arr
+      return this.visitNode(element.name, {
+        ...context,
+        variableDeclaration: {
+          ...context.variableDeclaration,
+          variableDeclarationInitializer: element.initializer
+            ? `(${initializer})`
+            : initializer,
+        },
+      }).trimStart();
+    })
+    .filter(Boolean)
+    .join(`;\n${variableDeclarationIndent}`);
 };

--- a/src/transformers/utils/common.ts
+++ b/src/transformers/utils/common.ts
@@ -136,7 +136,7 @@ export function visitParenthesized(
   node: ts.Node,
   context: VisitNodeContext,
 ): string {
-  const code = this.visitNode(node, context);
+  const code = this.visitNode(node, context).trim();
   return ts.isIdentifier(node) ? code : `(${code})`;
 }
 

--- a/tests/basics/transformInstanceofExpr.test.ts
+++ b/tests/basics/transformInstanceofExpr.test.ts
@@ -11,8 +11,8 @@ let myInstanceof = myFoo instanceof Foo;
       public function new() {}
 
     }
-    var  myFoo =  new Foo();
-    var  myInstanceof =  Std.isOfType(myFoo, Foo);
+    var myFoo = new Foo();
+    var myInstanceof = Std.isOfType(myFoo, Foo);
     "
   `);
 });

--- a/tests/basics/transformKeywords.test.ts
+++ b/tests/basics/transformKeywords.test.ts
@@ -32,19 +32,19 @@ let myNaN = NaN;
 `,
   ).resolves.toMatchInlineSnapshot(`
     "
-    var  myNumber:  Float;
-    var  myString:  String;
-    var  myBoolean:  Bool;
-    var  myUndefined:  Null<Any>;
-    var  myVoid:  () -> Void;
-    var  myNever:  Void;
-    var  myUnknown:  Any;
-    var  myAny:  Any;
-    var  myAsKeyword =  ( [] : Array< String>);
-    var  myAsyncAwait =  @async function() {
+    var myNumber: Float;
+    var myString: String;
+    var myBoolean: Bool;
+    var myUndefined: Null<Any>;
+    var myVoid: () -> Void;
+    var myNever: Void;
+    var myUnknown: Any;
+    var myAny: Any;
+    var myAsKeyword = ( [] : Array< String>);
+    var myAsyncAwait = @async function() {
       @await  Promise.resolve();
     };
-      final  myExport =  {};
+      final myExport = {};
      
      
     class MyReadonlyClass  {
@@ -58,10 +58,10 @@ let myNaN = NaN;
     typedef MyReadonlyType {
       public final myReadonly:  Float;
     }
-    var  myEqEqEqToken =  3 == "3";
-    var  myExEqEqToken =  3 != "3";
-    var  myUndefinedValue =  null;
-    var  myNaN =  Math.NaN;
+    var myEqEqEqToken = 3 == "3";
+    var myExEqEqToken = 3 != "3";
+    var myUndefinedValue = null;
+    var myNaN = Math.NaN;
     "
   `);
 });

--- a/tests/basics/transformPowExpr.test.ts
+++ b/tests/basics/transformPowExpr.test.ts
@@ -6,7 +6,7 @@ let myPow = 2 ** 3;
 myPow **= 4;
 `).resolves.toMatchInlineSnapshot(`
     "
-    var  myPow =  Math.pow( 2,  3);
+    var myPow = Math.pow( 2,  3);
 
     myPow = Math.pow(myPow,  4);
     "

--- a/tests/basics/transformRegex.test.ts
+++ b/tests/basics/transformRegex.test.ts
@@ -5,7 +5,7 @@ test('transforms regex', async () => {
 let myRegex = /[a-z]{0,9}/gim;
 `).resolves.toMatchInlineSnapshot(`
     "
-    var  myRegex =  ~/[a-z]{0,9}/gim;
+    var myRegex = ~/[a-z]{0,9}/gim;
     "
   `);
 });

--- a/tests/basics/transformTemplateStrings.test.ts
+++ b/tests/basics/transformTemplateStrings.test.ts
@@ -5,7 +5,7 @@ test('transforms simple template string literal', async () => {
 let myLiteral = \`"Hello"\`;
 `).resolves.toMatchInlineSnapshot(`
     "
-    var  myLiteral =  "\\"Hello\\"";
+    var myLiteral = "\\"Hello\\"";
     "
   `);
 });
@@ -16,6 +16,6 @@ test('transforms template string literal expression', async () => {
       'let myLiteral = `foo ${varX} bar ${varY ? `inner ${varZ} end` : ""} baz`;',
     ),
   ).resolves.toEqual(
-    "var  myLiteral =  'foo ${varX} bar ${(varY != null) ? 'inner ${varZ} end' : \"\"} baz';",
+    "var myLiteral = 'foo ${varX} bar ${(varY != null) ? 'inner ${varZ} end' : \"\"} baz';",
   );
 });

--- a/tests/basics/transformTypeofExpr.test.ts
+++ b/tests/basics/transformTypeofExpr.test.ts
@@ -6,8 +6,8 @@ let myString = "foo";
 let myTypeof = typeof myString;
 `).resolves.toMatchInlineSnapshot(`
     "
-    var  myString =  "foo";
-    var  myTypeof =  Ts2hx.typeof( myString);
+    var myString = "foo";
+    var myTypeof = Ts2hx.typeof( myString);
     "
   `);
 });

--- a/tests/basics/transformVoidExpr.test.ts
+++ b/tests/basics/transformVoidExpr.test.ts
@@ -7,7 +7,7 @@ void 0;
 void (myFnCall());
 `).resolves.toMatchInlineSnapshot(`
     "
-    var  myVoid =  null;
+    var myVoid = null;
     null;
     (function() { (myFnCall());})();
     "

--- a/tests/conditions/transformConditions.test.ts
+++ b/tests/conditions/transformConditions.test.ts
@@ -44,22 +44,22 @@ if (Foo) {} else if (myFoo) {}
       "import haxe.extern.EitherType;
 
 
-      final  myBoolean:  Bool =  true;
-      final  myTrue:  Bool =  true;
-      final  myFalse:  Bool =  false;
-      final  myNumber =  0;
-      final  myString =  "foo";
-      final  myTen:  Float =  10;
-      final  myBar:  String =  "bar";
-      final  myUnion:  EitherType< String,  String> =  'foo';
-      final  myObject =  { foo: 'bar' };
-      final  myArray =  [1, 2, 3];
-      final  myFunction =  () -> 0;
+      final myBoolean: Bool = true;
+      final myTrue: Bool = true;
+      final myFalse: Bool = false;
+      final myNumber = 0;
+      final myString = "foo";
+      final myTen: Float = 10;
+      final myBar: String = "bar";
+      final myUnion: EitherType< String,  String> = 'foo';
+      final myObject = { foo: 'bar' };
+      final myArray = [1, 2, 3];
+      final myFunction = () -> 0;
       class Foo  {
         public function new() {}
 
       }
-      final  myFoo =  new Foo();
+      final myFoo = new Foo();
 
       if (myBoolean) {} else if (myTrue) {} else if (myFalse) {}
       if (myNumber != 0) {} else if (myString != "") {}
@@ -76,8 +76,8 @@ const myStr = '';
 const myVar = myStr ? 1 : 0;
     `).resolves.toMatchInlineSnapshot(`
       "
-      final  myStr =  '';
-      final  myVar =  ( myStr != "") ? 1 : 0;
+      final myStr = '';
+      final myVar = ( myStr != "") ? 1 : 0;
           "
     `);
   });
@@ -109,7 +109,7 @@ for (let myVar = 10; myVar;) {}
       "
       while (true) {}
       do {} while ("a".repeat(2) != "") {}
-      var  myVar =  10;
+      var myVar = 10;
       while(( myVar != 0)) {
       }
                   "
@@ -124,10 +124,10 @@ const c = a || (b || "foo");
 const d = c && !("bar".repeat(2)) && 0;
             `).resolves.toMatchInlineSnapshot(`
       "
-      final  a =  "";
-      final  b =   a.or( "default");
-      final  c =   a.or( (b.or( "foo")));
-      final  d =  (  c.and( !("bar".repeat(2) != ""))).and( 0);
+      final a = "";
+      final b = a.or( "default");
+      final c = a.or( (b.or( "foo")));
+      final d = (c.and( !("bar".repeat(2) != ""))).and( 0);
                   "
     `);
   });

--- a/tests/objects/transformObjectLiteralExpression.test.ts
+++ b/tests/objects/transformObjectLiteralExpression.test.ts
@@ -14,16 +14,16 @@ let inverted = { foo: 'bar', ...fooBar, bar: "baz", ...barFoo, tuz: "qax" };
 let pairs = { foo: 'bar', bar: "baz", ...fooBar, ...barFoo, tuz: "qax", sha: "hoo" };
   `).resolves.toMatchInlineSnapshot(`
     "
-    var  fooBar =  { foo: "bar" };
-    var  barFoo =  { bar: "x", foo: "y" };
-    var  single =  fooBar;
-    var  double =  fooBar.combine(barFoo);
-    var  first =  fooBar.combine(barFoo).combine({ foo: 'bar', bar: "baz"});
-    var  middle =  { foo: 'bar'}.combine(fooBar).combine(barFoo).combine({ bar: "baz"});
-    var  last =  { foo: 'bar', bar: "baz"}.combine(fooBar).combine(barFoo);
-    var  changing =  fooBar.combine({ foo: 'bar'}).combine(barFoo).combine({ bar: "baz"}).combine(barFoo);
-    var  inverted =  { foo: 'bar'}.combine(fooBar).combine({ bar: "baz"}).combine(barFoo).combine({ tuz: "qax"});
-    var  pairs =  { foo: 'bar', bar: "baz"}.combine(fooBar).combine(barFoo).combine({ tuz: "qax", sha: "hoo"});
+    var fooBar = { foo: "bar" };
+    var barFoo = { bar: "x", foo: "y" };
+    var single = fooBar;
+    var double = fooBar.combine(barFoo);
+    var first = fooBar.combine(barFoo).combine({ foo: 'bar', bar: "baz"});
+    var middle = { foo: 'bar'}.combine(fooBar).combine(barFoo).combine({ bar: "baz"});
+    var last = { foo: 'bar', bar: "baz"}.combine(fooBar).combine(barFoo);
+    var changing = fooBar.combine({ foo: 'bar'}).combine(barFoo).combine({ bar: "baz"}).combine(barFoo);
+    var inverted = { foo: 'bar'}.combine(fooBar).combine({ bar: "baz"}).combine(barFoo).combine({ tuz: "qax"});
+    var pairs = { foo: 'bar', bar: "baz"}.combine(fooBar).combine(barFoo).combine({ tuz: "qax", sha: "hoo"});
       "
   `);
 });
@@ -33,7 +33,7 @@ test('transforms spread assignment of object literal expression', async () => {
 let fooBar = { foo: 'bar', ...({ hello: "world" }),  bar: "baz" };
   `).resolves.toMatchInlineSnapshot(`
     "
-    var  fooBar =  { foo: 'bar'}.combine(({ hello: "world" })).combine({  bar: "baz"});
+    var fooBar = { foo: 'bar'}.combine(({ hello: "world" })).combine({  bar: "baz"});
       "
   `);
 });

--- a/tests/objects/transformShorthandPropertyAssignment.test.ts
+++ b/tests/objects/transformShorthandPropertyAssignment.test.ts
@@ -6,8 +6,8 @@ let foo = "bar";
 let bar = { foo };
   `).resolves.toMatchInlineSnapshot(`
     "
-    var  foo =  "bar";
-    var  bar =  { foo: foo };
+    var foo = "bar";
+    var bar = { foo: foo };
       "
   `);
 });

--- a/tests/variables/transformBindingPattern.test.ts
+++ b/tests/variables/transformBindingPattern.test.ts
@@ -9,6 +9,11 @@ test('transforms binding patterns in variable declarations', async () => {
   const { 'foo': foo = 'foo', 0: bar = 'bar' } = obj;
   const { [foo1 + 'foo']: { [bar1]: baz = 'baz' }, [foo2]: [bar2] = ['bar2'] } = obj;
   const { [foo1 + 'foo']: { [bar1]: baz = 'baz' }, 'foo': foo, '0': first, bar, ...rest } = obj;
+  const { 
+    foo = () => {
+      const { innerProp } = innerObj;
+    }
+  } = obj;
 `).resolves.toMatchInlineSnapshot(`
     "
       final bar = obj.foo ?? 'foo';
@@ -28,6 +33,9 @@ test('transforms binding patterns in variable declarations', async () => {
       final first = Reflect.field(obj, '0');
       final bar = obj.bar;
       final rest = Ts2hx.rest(obj, [foo1 + 'foo', 'foo', '0', 'bar']);
+      final foo = obj.foo ?? function () {
+          final innerProp = innerObj.innerProp;
+        };
     "
   `);
 });

--- a/tests/variables/transformBindingPattern.test.ts
+++ b/tests/variables/transformBindingPattern.test.ts
@@ -1,0 +1,33 @@
+import { ts2hx } from '@tests/framework';
+
+test('transforms binding patterns in variable declarations', async () => {
+  await expect(ts2hx`
+  const { foo: bar = 'foo' } = obj;
+  const [first = '', , third = 0, { foo = 'foo' } = {}, ...rest] = arr;
+  let { foo: { bar: baz } } = obj;
+  const { foo: { bar: [baz1 = 'baz1', { baz2 = 0 } = {}] = [] } = {} } = obj ?? {};
+  const { 'foo': foo = 'foo', 0: bar = 'bar' } = obj;
+  const { [foo1 + 'foo']: { [bar1]: baz = 'baz' }, [foo2]: [bar2] = ['bar2'] } = obj;
+  const { [foo1 + 'foo']: { [bar1]: baz = 'baz' }, 'foo': foo, '0': first, bar, ...rest } = obj;
+`).resolves.toMatchInlineSnapshot(`
+    "
+      final bar = obj.foo ?? 'foo';
+      final first = arr[0] ?? '';
+      final third = arr[2] ?? 0;
+      final foo = (arr[3] ?? {}).foo ?? 'foo';
+      final rest = arr.slice(4);
+      var baz = obj.foo.bar;
+      final baz1 = (((obj ?? {}).foo ?? {}).bar ?? [])[0] ?? 'baz1';
+      final baz2 = ((((obj ?? {}).foo ?? {}).bar ?? [])[1] ?? {}).baz2 ?? 0;
+      final foo = Reflect.field(obj, 'foo') ?? 'foo';
+      final bar = Reflect.field(obj, '0') ?? 'bar';
+      final baz = Reflect.field(Reflect.field(obj, foo1 + 'foo'), bar1) ?? 'baz';
+      final bar2 = (Reflect.field(obj, foo2) ?? ['bar2'])[0];
+      final baz = Reflect.field(Reflect.field(obj, foo1 + 'foo'), bar1) ?? 'baz';
+      final foo = Reflect.field(obj, 'foo');
+      final first = Reflect.field(obj, '0');
+      final bar = obj.bar;
+      final rest = Ts2hx.rest(obj, [foo1 + 'foo', 'foo', '0', 'bar']);
+    "
+  `);
+});


### PR DESCRIPTION
- computed properties (also string and number literals) now handled properly;
- fixed nested destructuring of object (array) inside another destructuring.