### PR TITLE
feat: transformed parameter declarations 

### DIFF
--- a/src/transformers/index.ts
+++ b/src/transformers/index.ts
@@ -10,6 +10,9 @@ export { api, lang };
 export const TRANSFORMERS: TransformerFn[] = [
   tr.transformPowExpression,
   tr.transformMethodOnObject,
+  tr.transformDestructuredVariableDeclarationInForOf,
+  tr.transformDestructuredVariableDeclarationInCatch,
+  tr.transformParameterDeclaration,
 ];
 
 // Order here actually matters (to some extent)

--- a/src/transformers/lang/variables.ts
+++ b/src/transformers/lang/variables.ts
@@ -58,11 +58,10 @@ export const transformVariableDeclaration: EmitFn = function (
     }`;
   }
 
-  // avoid destructuring of parameter in catch clause
   if (!keyword) {
     return this.utils.commentOutNode(
       node,
-      'Parameter destructuring is not allowed in catch clause',
+      'Parameter destructuring is not allowed out of variable declaration list',
     );
   }
 

--- a/src/transformers/ts/functions.ts
+++ b/src/transformers/ts/functions.ts
@@ -1,0 +1,140 @@
+import ts from 'typescript';
+import { type TransformerFn, type Transpiler } from '../Transpiler';
+
+export const transformParameterDeclaration: TransformerFn = function (
+  this: Transpiler,
+  node,
+  context,
+) {
+  const shouldParameterDeclarationBeMoved = (
+    parameter: ts.ParameterDeclaration,
+  ): boolean => {
+    return (
+      !ts.isIdentifier(parameter.name) ||
+      (!!parameter.initializer &&
+        !this.utils.isSimpleType(parameter.initializer))
+    );
+  };
+
+  if (
+    !ts.isFunctionLike(node) ||
+    ts.isTypeNode(node) ||
+    !('body' in node) ||
+    !node.body ||
+    !node.parameters.some(shouldParameterDeclarationBeMoved)
+  ) {
+    return;
+  }
+
+  let newBody = this.utils.ensureNodeIsBlock(node.body, context);
+  const parametersToMove: Array<{
+    newName: ts.Identifier;
+    node: ts.ParameterDeclaration;
+  }> = [];
+
+  const newParameters = node.parameters.map((parameter) => {
+    if (!shouldParameterDeclarationBeMoved(parameter)) return parameter;
+
+    const newParameterName = context.factory.createUniqueName('param');
+    parametersToMove.unshift({
+      newName: newParameterName,
+      node: parameter,
+    });
+
+    return context.factory.updateParameterDeclaration(
+      parameter,
+      parameter.modifiers,
+      undefined,
+      newParameterName,
+      parameter.questionToken,
+      parameter.type,
+      undefined,
+    );
+  });
+
+  parametersToMove.forEach(({ newName, node }) => {
+    newBody = this.utils.moveVariableOrParameterDeclarationToBlock(
+      node,
+      newName,
+      newBody,
+      context,
+    );
+  });
+
+  // const foo = ({ bar }) => bar;
+  if (ts.isArrowFunction(node)) {
+    return context.factory.updateArrowFunction(
+      node,
+      node.modifiers,
+      node.typeParameters,
+      newParameters,
+      node.type,
+      node.equalsGreaterThanToken,
+      newBody,
+    );
+  }
+
+  // function foo({ bar }) {}
+  if (ts.isFunctionDeclaration(node)) {
+    return context.factory.updateFunctionDeclaration(
+      node,
+      node.modifiers,
+      node.asteriskToken,
+      node.name,
+      node.typeParameters,
+      newParameters,
+      node.type,
+      newBody,
+    );
+  }
+
+  // class Foo { set bar({ baz }) {} }
+  if (ts.isSetAccessor(node)) {
+    return context.factory.updateSetAccessorDeclaration(
+      node,
+      node.modifiers,
+      node.name,
+      newParameters,
+      newBody,
+    );
+  }
+
+  // class Foo { constructor({ bar }) {} }
+  if (ts.isConstructorDeclaration(node)) {
+    return context.factory.updateConstructorDeclaration(
+      node,
+      node.modifiers,
+      newParameters,
+      newBody,
+    );
+  }
+
+  // class Foo { foo({ bar }) {} }
+  if (ts.isMethodDeclaration(node)) {
+    return context.factory.updateMethodDeclaration(
+      node,
+      node.modifiers,
+      node.asteriskToken,
+      node.name,
+      node.questionToken,
+      node.typeParameters,
+      newParameters,
+      node.type,
+      newBody,
+    );
+  }
+
+  // const foo = function({ bar }) {}
+  if (ts.isFunctionExpression(node)) {
+    return context.factory.updateFunctionExpression(
+      node,
+      node.modifiers,
+      node.asteriskToken,
+      node.name,
+      node.typeParameters,
+      newParameters,
+      node.type,
+      newBody,
+    );
+  }
+};

--- a/src/transformers/ts/functions.ts
+++ b/src/transformers/ts/functions.ts
@@ -6,22 +6,12 @@ export const transformParameterDeclaration: TransformerFn = function (
   node,
   context,
 ) {
-  const shouldParameterDeclarationBeMoved = (
-    parameter: ts.ParameterDeclaration,
-  ): boolean => {
-    return (
-      !ts.isIdentifier(parameter.name) ||
-      (!!parameter.initializer &&
-        !this.utils.isSimpleType(parameter.initializer))
-    );
-  };
-
   if (
     !ts.isFunctionLike(node) ||
     ts.isTypeNode(node) ||
     !('body' in node) ||
     !node.body ||
-    !node.parameters.some(shouldParameterDeclarationBeMoved)
+    node.parameters.every(this.utils.isAcceptableParameterDeclarationForHx)
   ) {
     return;
   }
@@ -33,7 +23,9 @@ export const transformParameterDeclaration: TransformerFn = function (
   }> = [];
 
   const newParameters = node.parameters.map((parameter) => {
-    if (!shouldParameterDeclarationBeMoved(parameter)) return parameter;
+    if (this.utils.isAcceptableParameterDeclarationForHx(parameter)) {
+      return parameter;
+    }
 
     const newParameterName = context.factory.createUniqueName('param');
     parametersToMove.unshift({

--- a/src/transformers/ts/index.ts
+++ b/src/transformers/ts/index.ts
@@ -1,2 +1,4 @@
 export * from './basics';
+export * from './functions';
 export * from './objects';
+export * from './variables';

--- a/src/transformers/ts/variables.ts
+++ b/src/transformers/ts/variables.ts
@@ -1,0 +1,83 @@
+import ts from 'typescript';
+import { type TransformerFn, type Transpiler } from '../Transpiler';
+
+export const transformDestructuredVariableDeclarationInForOf: TransformerFn =
+  function (this: Transpiler, node, context) {
+    // for (const { foo, bar } of fooBars) {} ->
+    // for (const fooBarsItem of fooBars) { const { foo, bar } = fooBarsItem; }
+    if (
+      !ts.isForOfStatement(node) ||
+      !ts.isVariableDeclarationList(node.initializer) ||
+      !ts.isVariableDeclaration(node.initializer.declarations[0]) ||
+      ts.isIdentifier(node.initializer.declarations[0].name)
+    ) {
+      return;
+    }
+
+    const [variableDeclaration] = node.initializer.declarations;
+    if (
+      !ts.isVariableDeclaration(variableDeclaration) ||
+      ts.isIdentifier(variableDeclaration.name)
+    ) {
+      return;
+    }
+
+    const generatedNameText = ts.isIdentifier(node.expression)
+      ? `${node.expression.text}Item`
+      : 'item';
+    const generatedIdentifier =
+      context.factory.createUniqueName(generatedNameText);
+
+    return context.factory.updateForOfStatement(
+      node,
+      node.awaitModifier,
+      context.factory.updateVariableDeclarationList(node.initializer, [
+        context.factory.updateVariableDeclaration(
+          variableDeclaration,
+          generatedIdentifier,
+          variableDeclaration.exclamationToken,
+          variableDeclaration.type,
+          variableDeclaration.initializer,
+        ),
+      ]),
+      node.expression,
+      this.utils.moveVariableOrParameterDeclarationToBlock(
+        variableDeclaration,
+        generatedIdentifier,
+        this.utils.ensureNodeIsBlock(node.statement, context),
+        context,
+      ),
+    );
+  };
+
+export const transformDestructuredVariableDeclarationInCatch: TransformerFn =
+  function (this: Transpiler, node, context) {
+    // try {} catch ({ message }) {} ->
+    // try {} catch (error) { const { message } = error; }
+    if (
+      !ts.isCatchClause(node) ||
+      !node.variableDeclaration ||
+      ts.isIdentifier(node.variableDeclaration)
+    ) {
+      return;
+    }
+
+    const generatedIdentifier = context.factory.createUniqueName('error');
+
+    return context.factory.updateCatchClause(
+      node,
+      context.factory.updateVariableDeclaration(
+        node.variableDeclaration,
+        generatedIdentifier,
+        node.variableDeclaration.exclamationToken,
+        node.variableDeclaration.type,
+        node.variableDeclaration.initializer,
+      ),
+      this.utils.moveVariableOrParameterDeclarationToBlock(
+        node.variableDeclaration,
+        generatedIdentifier,
+        node.block,
+        context,
+      ),
+    );
+  };

--- a/src/transformers/ts/variables.ts
+++ b/src/transformers/ts/variables.ts
@@ -21,12 +21,7 @@ export const transformDestructuredVariableDeclarationInForOf: TransformerFn =
     ) {
       return;
     }
-
-    const generatedNameText = ts.isIdentifier(node.expression)
-      ? `${node.expression.text}Item`
-      : 'item';
-    const generatedIdentifier =
-      context.factory.createUniqueName(generatedNameText);
+    const generatedIdentifier = context.factory.createUniqueName('element');
 
     return context.factory.updateForOfStatement(
       node,

--- a/src/transformers/utils/common.ts
+++ b/src/transformers/utils/common.ts
@@ -177,3 +177,20 @@ export function renameSymbol(
   symbolsMap.set(this.typeChecker.getSymbolAtLocation(node)!, name);
   return name;
 }
+
+export function ensureNodeIsBlock(
+  this: Transpiler,
+  node: ts.Statement | ts.Expression | ts.Block,
+  context: ts.TransformationContext,
+): ts.Block {
+  if (ts.isBlock(node)) return node;
+  if (ts.isStatement(node)) return context.factory.createBlock([node], true);
+  if (ts.isExpression(node) && ts.isArrowFunction(node.parent)) {
+    return context.factory.createBlock(
+      [context.factory.createReturnStatement(node)],
+      true,
+    );
+  }
+
+  throw new Error('Unable to transform node to Block');
+}

--- a/src/transformers/utils/functions.ts
+++ b/src/transformers/utils/functions.ts
@@ -1,6 +1,16 @@
 import ts from 'typescript';
 import { type Transpiler } from '../Transpiler';
 
+export function isAcceptableParameterDeclarationForHx(
+  this: Transpiler,
+  parameter: ts.ParameterDeclaration,
+): boolean {
+  return (
+    ts.isIdentifier(parameter.name) &&
+    (!parameter.initializer || this.utils.isSimpleType(parameter.initializer))
+  );
+}
+
 export function moveVariableOrParameterDeclarationToBlock(
   this: Transpiler,
   base: ts.VariableDeclaration | ts.ParameterDeclaration,

--- a/src/transformers/utils/functions.ts
+++ b/src/transformers/utils/functions.ts
@@ -1,0 +1,41 @@
+import ts from 'typescript';
+import { type Transpiler } from '../Transpiler';
+
+export function moveVariableOrParameterDeclarationToBlock(
+  this: Transpiler,
+  base: ts.VariableDeclaration | ts.ParameterDeclaration,
+  identifier: ts.Identifier,
+  block: ts.Block,
+  context: ts.TransformationContext,
+): ts.Block {
+  const initializer =
+    base.initializer && !this.utils.isSimpleType(base.initializer)
+      ? context.factory.createBinaryExpression(
+          identifier,
+          context.factory.createToken(ts.SyntaxKind.QuestionQuestionToken),
+          base.initializer,
+        )
+      : identifier;
+  const newVariableStatement = context.factory.createVariableStatement(
+    undefined,
+    context.factory.createVariableDeclarationList(
+      [
+        context.factory.createVariableDeclaration(
+          base.name,
+          'exclamationToken' in base ? base.exclamationToken : undefined,
+          base.type,
+          initializer,
+        ),
+      ],
+      base.parent.flags || 2,
+    ),
+  );
+
+  return context.factory.updateBlock(
+    block,
+    context.factory.createNodeArray([
+      newVariableStatement,
+      ...block.statements,
+    ]),
+  );
+}

--- a/src/transformers/utils/index.ts
+++ b/src/transformers/utils/index.ts
@@ -5,3 +5,4 @@ export * from './expressions';
 export * from './modifiers';
 export * from './modules';
 export * from './types';
+export * from './functions';

--- a/src/transformers/utils/types.ts
+++ b/src/transformers/utils/types.ts
@@ -88,15 +88,18 @@ export function getNodeTypeString(
 }
 
 export function isSimpleType(this: Transpiler, node: ts.Node): boolean {
-  const symbol = this.typeChecker.getSymbolAtLocation(node);
-  return (
+  if (
     ts.isStringLiteral(node) ||
     ts.isNumericLiteral(node) ||
     ts.isNoSubstitutionTemplateLiteral(node) ||
     node.kind === ts.SyntaxKind.TrueKeyword ||
     node.kind === ts.SyntaxKind.FalseKeyword ||
     node.kind === ts.SyntaxKind.NullKeyword ||
-    node.kind === ts.SyntaxKind.UndefinedKeyword ||
-    (!!symbol && this.typeChecker.isUndefinedSymbol(symbol))
-  );
+    node.kind === ts.SyntaxKind.UndefinedKeyword
+  ) {
+    return true;
+  }
+
+  const symbol = this.typeChecker.getSymbolAtLocation(node);
+  return !!symbol && this.typeChecker.isUndefinedSymbol(symbol);
 }

--- a/src/transformers/utils/types.ts
+++ b/src/transformers/utils/types.ts
@@ -86,3 +86,18 @@ export function getNodeTypeString(
     'Void'
   );
 }
+
+export function isSimpleType(this: Transpiler, node: ts.Node): boolean {
+  const symbol = this.typeChecker.getSymbolAtLocation(node);
+  return (
+    ts.isStringLiteral(node) ||
+    ts.isNumericLiteral(node) ||
+    ts.isNoSubstitutionTemplateLiteral(node) ||
+    node.kind === ts.SyntaxKind.TrueKeyword ||
+    node.kind === ts.SyntaxKind.FalseKeyword ||
+    node.kind === ts.SyntaxKind.NullKeyword ||
+    node.kind === ts.SyntaxKind.VoidExpression ||
+    node.kind === ts.SyntaxKind.UndefinedKeyword ||
+    (!!symbol && this.typeChecker.isUndefinedSymbol(symbol))
+  );
+}

--- a/src/transformers/utils/types.ts
+++ b/src/transformers/utils/types.ts
@@ -96,7 +96,6 @@ export function isSimpleType(this: Transpiler, node: ts.Node): boolean {
     node.kind === ts.SyntaxKind.TrueKeyword ||
     node.kind === ts.SyntaxKind.FalseKeyword ||
     node.kind === ts.SyntaxKind.NullKeyword ||
-    node.kind === ts.SyntaxKind.VoidExpression ||
     node.kind === ts.SyntaxKind.UndefinedKeyword ||
     (!!symbol && this.typeChecker.isUndefinedSymbol(symbol))
   );

--- a/tests/functions/transformFunctionParameterBindingPattern.test.ts
+++ b/tests/functions/transformFunctionParameterBindingPattern.test.ts
@@ -1,0 +1,155 @@
+import { ts2hx } from '@tests/framework';
+
+test('transforms binding patterns in parameter declarations in function', async () => {
+  await expect(ts2hx`
+  function foo({ bar }: { bar: string }, [baz = bar]: string[], ...rest: string[]) {
+  }
+  const foo1 = function({ bar = 'bar' }: { bar?: string } = {}, [baz]: number[] = [], id = bar): void {
+  };
+  class Foo {
+    foo = function<T extends string = string>(baz: T, { bar = baz }: { bar?: string }): T  {
+      return baz;
+    }
+  }
+`).resolves.toMatchInlineSnapshot(`
+    "function foo(param_1:  {
+        public var bar:  String;
+    }, param_2:  Array< String>, ...rest:  String) {
+        var bar = param_1.bar;
+        var baz = param_2[0] ?? bar;
+    }
+    final foo1 = function (param_3:  {
+        public var ?bar:  String;
+    }, param_4:  Array< Float>, param_5): Void {
+        var bar = (param_3 ?? {}).bar ?? 'bar';
+        var baz = (param_4 ?? [])[0];
+        var id = param_5 ?? bar;
+    };
+    class Foo  {
+      public function new() {}
+
+        public var foo=  function <T :  String>(baz:  T, param_6:  {
+            public var ?bar:  String;
+        }): T {
+            final bar = param_6.bar ?? baz;
+            return baz;
+        };
+    }
+    "
+  `);
+});
+
+test('transforms binding patterns in parameter declarations in arrow function', async () => {
+  await expect(ts2hx`
+  const fooArrow = ({ bar }: { bar: string }, [baz = bar]: string[], ...rest: string[]): null => null;
+  const fooArrow1 = ({ bar = 'bar' }: { bar?: string } = {}, [baz]: number[] = [], id?: string): void => {
+  };
+  class Foo {
+    foo = ({ bar = 'bar' }: { bar?: string }): null => null;
+  }
+`).resolves.toMatchInlineSnapshot(`
+    "final fooArrow = function (param_1:  {
+        public var bar:  String;
+    },  param_2:  Array< String>,  ...rest:  String):  Null<Any> {
+        var bar = param_1.bar;
+        var baz = param_2[0] ?? bar;
+        return null;
+    };
+    final fooArrow1 = function (param_3:  {
+        public var ?bar:  String;
+    },  param_4:  Array< Float>,  ?id:  String):  Void {
+        var bar = (param_3 ?? {}).bar ?? 'bar';
+        var baz = (param_4 ?? [])[0];
+    };
+    class Foo  {
+      public function new() {}
+
+        public var foo=  function (param_5:  {
+            public var ?bar:  String;
+        }):  Null<Any> {
+            var bar = param_5.bar ?? 'bar';
+            return null;
+        };
+    }
+    "
+  `);
+});
+
+test('transforms binding patterns in parameter declarations in method', async () => {
+  await expect(ts2hx`
+  class Foo {
+    foo([baz]: string[], { bar: { foobar = baz } }: { bar: { foobar: string; } }): string  {
+      return baz;
+    }
+  }
+`).resolves.toMatchInlineSnapshot(`
+    "class Foo  {
+      public function new() {}
+
+        public function foo(param_1:  Array< String>,  param_2:  {
+            public var bar:  {
+                public var foobar:  String;
+            };
+        }):  String {
+            final baz = param_1[0];
+            final foobar = param_2.bar.foobar ?? baz;
+            return baz;
+        }
+    }
+    "
+  `);
+});
+
+test('transforms binding patterns in parameter declarations in set accessor', async () => {
+  await expect(ts2hx`
+  class Foo {
+    _bar: { bar: string } = { bar: 'bar' };
+    set Bar({ bar = '' } : { bar?: string }) {
+      this._bar = { bar };
+    }
+  }
+`).resolves.toMatchInlineSnapshot(`
+    "class Foo  {
+      public function new() {}
+
+        public var _bar:  {
+            public var bar:  String;
+        }=  { bar: 'bar' };
+        public var Bar(never, set):  {
+            public var ?bar:  String;
+        };
+        public function set_Bar(param_1:  {
+            public var ?bar:  String;
+        }){
+            var bar = param_1.bar ?? '';
+    return (
+            this._bar = { bar: bar } );}
+    }
+    "
+  `);
+});
+
+test('transforms binding patterns in parameter declarations in constructor', async () => {
+  await expect(ts2hx`
+  class Foo {
+    _bar: { bar: string } = { bar: 'bar' };
+    constructor({ bar = '' } : { bar?: string }) {
+      this._bar = { bar };
+    }
+  }
+`).resolves.toMatchInlineSnapshot(`
+    "class Foo  {
+        public var _bar:  {
+            public var bar:  String;
+        }=  { bar: 'bar' };
+        public function new(param_1:  {
+            public var ?bar:  String;
+        }) {
+            var bar = param_1.bar ?? '';
+
+            this._bar = { bar: bar };
+        }
+    }
+    "
+  `);
+});

--- a/tests/functions/transformFunctionParameterInitialization.test.ts
+++ b/tests/functions/transformFunctionParameterInitialization.test.ts
@@ -1,0 +1,32 @@
+import { ts2hx } from '@tests/framework';
+
+test('save simple parameter initialization', async () => {
+  await expect(ts2hx`
+  function foo(a = true, b = false, c = 1, d = 'foo', e = \`null\`, f = null, g = undefined) {
+  }
+`).resolves.toMatchInlineSnapshot(`
+    "function foo(a =  true, b =  false, c =  1, d =  'foo', e =  "null", f =  null, g =  null) {
+    }
+    "
+  `);
+});
+
+test('transform dynamic parameter initialization', async () => {
+  await expect(ts2hx`
+  const bar = 'bar';
+  function foo(a = !true, b = 1 + 1, c = \`foo\${bar}\`, d = {}, e = [], f = () => {}, g = foo()) {
+  }
+`).resolves.toMatchInlineSnapshot(`
+    "final bar = 'bar';
+    function foo(param_1, param_2, param_3, param_4, param_5, param_6, param_7) {
+        var a = param_1 ?? !true;
+        var b = param_2 ?? 1 + 1;
+        var c = param_3 ?? 'foo\${bar}';
+        var d = param_4 ?? {};
+        var e = param_5 ?? [];
+        var f = param_6 ?? (function () { });
+        var g = param_7 ??  foo();
+    }
+    "
+  `);
+});

--- a/tests/variables/transformBindingPattern.test.ts
+++ b/tests/variables/transformBindingPattern.test.ts
@@ -47,12 +47,12 @@ test('transforms variable declaration with binding pattern inside for-of', async
     for (const [{ foo1, bar1 }] of fooBars) {}
   }
 `).resolves.toMatchInlineSnapshot(`
-    "for ( fooBarsItem_1 in  fooBars)  {
-        final foo = fooBarsItem_1.foo;
-        final bar = fooBarsItem_1.bar;
-        for ( fooBarsItem_2 in  fooBars)  {
-            final foo1 = fooBarsItem_2[0].foo1;
-            final bar1 = fooBarsItem_2[0].bar1;
+    "for ( element_1 in  fooBars)  {
+        final foo = element_1.foo;
+        final bar = element_1.bar;
+        for ( element_2 in  fooBars)  {
+            final foo1 = element_2[0].foo1;
+            final bar1 = element_2[0].bar1;
         }
     }
     "


### PR DESCRIPTION
- parameters with destructuring replaced with an identifier and moved into the body;
- parameters with not simple initializer also replaced with an identifier and moved into the body;
- parameter with destructuring in catch clause replaced with an identifier and moved into the body;
- fixed for-of with destructuring in a variable declaration.